### PR TITLE
Complete CRUD operation for Request 

### DIFF
--- a/src/main/java/com/mthree/petadoption/controller/RequestController.java
+++ b/src/main/java/com/mthree/petadoption/controller/RequestController.java
@@ -25,8 +25,9 @@ public class RequestController {
     @PostMapping ("/api/requests")
     public Request addRequest(Request request){ return requestService.submitRequest(request);}
 
-    @PutMapping("/api/update")
-    public void updateRequest(Long requestId, Long petId, String status){requestService.updateRequest(requestId, petId, status);}
+    @PutMapping("/api/update/{id}")
+    public void updateRequest(@PathVariable("id") Long id, @RequestParam(required = false) Long petId,
+        @RequestParam(required = false) String status){requestService.updateRequest(id, petId, status);}
 
     @DeleteMapping("/api/{id}")
     public void deleteRequest(@PathVariable("id") Long id){ requestService.cancelRequest(id);}

--- a/src/main/java/com/mthree/petadoption/controller/RequestController.java
+++ b/src/main/java/com/mthree/petadoption/controller/RequestController.java
@@ -1,0 +1,34 @@
+package com.mthree.petadoption.controller;
+
+import com.mthree.petadoption.model.Request;
+import com.mthree.petadoption.service.RequestService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class RequestController {
+    private final RequestService requestService;
+
+    public RequestController(RequestService requestService){
+        this.requestService = requestService;
+    }
+
+    @GetMapping("/api/requests")
+    public List<Request> getAllRequests(){
+        return requestService.listAllRequests();
+    }
+
+    @GetMapping("/api/requests/{id}")
+    public Request getRequestById(@PathVariable("id") Long id){return requestService.viewRequest(id);}
+
+    @PostMapping ("/api/requests")
+    public Request addRequest(Request request){ return requestService.submitRequest(request);}
+
+    @PutMapping("/api/update")
+    public void updateRequest(Long requestId, Long petId, String status){requestService.updateRequest(requestId, petId, status);}
+
+    @DeleteMapping("/api/{id}")
+    public void deleteRequest(@PathVariable("id") Long id){ requestService.cancelRequest(id);}
+
+}

--- a/src/main/java/com/mthree/petadoption/controller/RequestController.java
+++ b/src/main/java/com/mthree/petadoption/controller/RequestController.java
@@ -22,7 +22,7 @@ public class RequestController {
         return ResponseEntity.status(HttpStatus.OK).body(requestList);
     }
 
-    @GetMapping("/api/requests/{id}")
+    @GetMapping("/api/request/{id}")
     public ResponseEntity<Request> getRequestById(@PathVariable("id") Long id){
         Request request = requestService.viewRequest(id);
         return ResponseEntity.status(HttpStatus.OK).body(request);
@@ -34,14 +34,14 @@ public class RequestController {
         return new ResponseEntity<Void>(HttpStatus.CREATED);
     }
 
-    @PutMapping("/api/update/{id}")
+    @PutMapping("/api/request/{id}")
     public ResponseEntity<Void> updateRequest(@PathVariable("id") Long id, @RequestParam(required = false) Long petId,
         @RequestParam(required = false) String status){
         requestService.updateRequest(id, petId, status);
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    @DeleteMapping("/api/{id}")
+    @DeleteMapping("/api/request/{id}")
     public ResponseEntity<Void> deleteRequest(@PathVariable("id") Long id){
         requestService.cancelRequest(id);
         return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/mthree/petadoption/controller/RequestController.java
+++ b/src/main/java/com/mthree/petadoption/controller/RequestController.java
@@ -2,6 +2,8 @@ package com.mthree.petadoption.controller;
 
 import com.mthree.petadoption.model.Request;
 import com.mthree.petadoption.service.RequestService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,21 +17,34 @@ public class RequestController {
     }
 
     @GetMapping("/api/requests")
-    public List<Request> getAllRequests(){
-        return requestService.listAllRequests();
+    public ResponseEntity<List<Request>> getAllRequests(){
+        List<Request> requestList = requestService.listAllRequests();
+        return ResponseEntity.status(HttpStatus.OK).body(requestList);
     }
 
     @GetMapping("/api/requests/{id}")
-    public Request getRequestById(@PathVariable("id") Long id){return requestService.viewRequest(id);}
+    public ResponseEntity<Request> getRequestById(@PathVariable("id") Long id){
+        Request request = requestService.viewRequest(id);
+        return ResponseEntity.status(HttpStatus.OK).body(request);
+    }
 
-    @PostMapping ("/api/requests")
-    public Request addRequest(Request request){ return requestService.submitRequest(request);}
+    @PostMapping ("/api/request")
+    public ResponseEntity<Void> addRequest(Request request){
+        requestService.submitRequest(request);
+        return new ResponseEntity<Void>(HttpStatus.CREATED);
+    }
 
     @PutMapping("/api/update/{id}")
-    public void updateRequest(@PathVariable("id") Long id, @RequestParam(required = false) Long petId,
-        @RequestParam(required = false) String status){requestService.updateRequest(id, petId, status);}
+    public ResponseEntity<Void> updateRequest(@PathVariable("id") Long id, @RequestParam(required = false) Long petId,
+        @RequestParam(required = false) String status){
+        requestService.updateRequest(id, petId, status);
+        return new ResponseEntity<Void>(HttpStatus.OK);
+    }
 
     @DeleteMapping("/api/{id}")
-    public void deleteRequest(@PathVariable("id") Long id){ requestService.cancelRequest(id);}
+    public ResponseEntity<Void> deleteRequest(@PathVariable("id") Long id){
+        requestService.cancelRequest(id);
+        return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+    }
 
 }

--- a/src/main/java/com/mthree/petadoption/dao/RequestDao.java
+++ b/src/main/java/com/mthree/petadoption/dao/RequestDao.java
@@ -12,7 +12,7 @@ public interface RequestDao {
 
     Request submitRequest(Request request);
 
-    void updateRequest(Request request);
+    Request updateRequest(Long requestId, Long petId, String status);
 
     void cancelRequest(long requestId);
 }

--- a/src/main/java/com/mthree/petadoption/dao/RequestDaoImpl.java
+++ b/src/main/java/com/mthree/petadoption/dao/RequestDaoImpl.java
@@ -1,13 +1,21 @@
 package com.mthree.petadoption.dao;
 
 import com.mthree.petadoption.model.Request;
+import com.mthree.petadoption.repository.PetRepository;
+import com.mthree.petadoption.repository.RequestRepository;
 
 import java.util.List;
 
 public class RequestDaoImpl implements RequestDao{
+    private RequestRepository requestRepository;
+
+    public RequestDaoImpl(PetRepository petRepository) {
+        this.requestRepository = requestRepository;
+    }
+
     @Override
     public List<Request> listAllRequests() {
-        return List.of();
+        return requestRepository.findAll();
     }
 
     @Override
@@ -17,7 +25,7 @@ public class RequestDaoImpl implements RequestDao{
 
     @Override
     public Request submitRequest(Request request) {
-        return null;
+        return requestRepository.save(request);
     }
 
     @Override
@@ -27,6 +35,6 @@ public class RequestDaoImpl implements RequestDao{
 
     @Override
     public void cancelRequest(long requestId) {
-
+        requestRepository.deleteById(requestId);
     }
 }

--- a/src/main/java/com/mthree/petadoption/dao/RequestDaoImpl.java
+++ b/src/main/java/com/mthree/petadoption/dao/RequestDaoImpl.java
@@ -1,18 +1,32 @@
 package com.mthree.petadoption.dao;
 
+import com.mthree.petadoption.model.Pet;
 import com.mthree.petadoption.model.Request;
 
+import com.mthree.petadoption.repository.PetRepository;
 import java.util.List;
+import org.springframework.stereotype.Repository;
+import com.mthree.petadoption.repository.RequestRepository;
 
+@Repository
 public class RequestDaoImpl implements RequestDao{
+
+    private final RequestRepository requestRepository;
+    private final PetRepository petRepository;
+
+    public RequestDaoImpl(RequestRepository requestRepository, PetRepository petRepository) {
+        this.requestRepository = requestRepository;
+        this.petRepository = petRepository;
+    }
+
     @Override
     public List<Request> listAllRequests() {
         return List.of();
     }
 
     @Override
-    public Request viewRequest(long requestId) {
-        return null;
+    public Request viewRequest(long requestId) { //Roosh
+        return requestRepository.findById(requestId).orElse(null);
     }
 
     @Override
@@ -21,7 +35,23 @@ public class RequestDaoImpl implements RequestDao{
     }
 
     @Override
-    public void updateRequest(Request request) {
+    public Request updateRequest(Long requestId, Long petId, String status) {
+        Request request = requestRepository.findRequestById(requestId);
+
+        if (petId != null) {
+            Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new RuntimeException("Pet not found with ID: " + petId));
+            request.setPet(pet);
+        }
+
+        if (status != null) {
+            try {
+                request.setStatus(Request.Status.valueOf(status.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                throw new RuntimeException("Invalid status value: " + status);
+            }
+        }
+        return requestRepository.save(request);
 
     }
 

--- a/src/main/java/com/mthree/petadoption/dao/RequestDaoImpl.java
+++ b/src/main/java/com/mthree/petadoption/dao/RequestDaoImpl.java
@@ -5,6 +5,8 @@ import com.mthree.petadoption.model.Request;
 
 import com.mthree.petadoption.repository.PetRepository;
 import java.util.List;
+
+import com.mthree.petadoption.repository.UserRepository;
 import org.springframework.stereotype.Repository;
 import com.mthree.petadoption.repository.RequestRepository;
 
@@ -13,10 +15,12 @@ public class RequestDaoImpl implements RequestDao{
 
     private final RequestRepository requestRepository;
     private final PetRepository petRepository;
+    private final UserRepository userRepository;
 
-    public RequestDaoImpl(RequestRepository requestRepository, PetRepository petRepository) {
+    public RequestDaoImpl(RequestRepository requestRepository, PetRepository petRepository, UserRepository userRepository) {
         this.requestRepository = requestRepository;
         this.petRepository = petRepository;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -31,6 +35,11 @@ public class RequestDaoImpl implements RequestDao{
 
     @Override
     public Request submitRequest(Request request) {
+        if(!userRepository.existsById(request.getUser().getUserId())){
+            throw new RuntimeException("Invalid User ID - request rejected");
+        } else if(!petRepository.existsById(request.getPet().getPetId())){
+            throw new RuntimeException("Invalid Pet ID - request rejected");
+        }
         return requestRepository.save(request);
     }
 

--- a/src/main/java/com/mthree/petadoption/dao/UserDaoImpl.java
+++ b/src/main/java/com/mthree/petadoption/dao/UserDaoImpl.java
@@ -25,6 +25,6 @@ public class UserDaoImpl implements UserDao{
 
     @Override
     public void updateUserInfo(long userId) {
-        
+
     }
 }

--- a/src/main/java/com/mthree/petadoption/model/Request.java
+++ b/src/main/java/com/mthree/petadoption/model/Request.java
@@ -73,5 +73,7 @@ public class Request {
   public void setStatus(Status status) {
     this.status = status;
   }
+
+  public void setRequestId(Long id){this.id = id;}
 }
 

--- a/src/main/java/com/mthree/petadoption/model/Request.java
+++ b/src/main/java/com/mthree/petadoption/model/Request.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 public class Request {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long requestId;
+  private Long id;
 
   @ManyToOne
   @JoinColumn(name = "pet_id")
@@ -51,7 +51,7 @@ public class Request {
   }
 
   public Long getRequestId() {
-    return requestId;
+    return id;
   }
 
   public void setPet(Pet pet) {

--- a/src/main/java/com/mthree/petadoption/model/User.java
+++ b/src/main/java/com/mthree/petadoption/model/User.java
@@ -7,7 +7,7 @@ import jakarta.persistence.*;
 public class User {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long userId;
+  private Long id;
 
   private String username;
   private String email;
@@ -21,8 +21,10 @@ public class User {
   }
 
   public Long getUserId() {
-    return userId;
+    return id;
   }
+
+  public void setUserId(Long id){this.id = id;}
 
   public String getUsername() {
     return username;

--- a/src/main/java/com/mthree/petadoption/repository/RequestRepository.java
+++ b/src/main/java/com/mthree/petadoption/repository/RequestRepository.java
@@ -4,5 +4,5 @@ import com.mthree.petadoption.model.Request;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
-
+  Request findRequestById(Long requestId);
 }

--- a/src/main/java/com/mthree/petadoption/service/RequestService.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestService.java
@@ -1,0 +1,4 @@
+package com.mthree.petadoption.service;
+
+public interface RequestService {
+}

--- a/src/main/java/com/mthree/petadoption/service/RequestService.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestService.java
@@ -12,7 +12,7 @@ public interface RequestService {
 
     Request submitRequest(Request request);
 
-    void updateRequest(Request request);
+    void updateRequest(Long requestId, Long petId, String status);
 
     void cancelRequest(long requestId);
 }

--- a/src/main/java/com/mthree/petadoption/service/RequestService.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestService.java
@@ -1,4 +1,18 @@
 package com.mthree.petadoption.service;
 
+import com.mthree.petadoption.model.Request;
+
+import java.util.List;
+
 public interface RequestService {
+
+    List<Request> listAllRequests();
+
+    Request viewRequest(long requestId);
+
+    Request submitRequest(Request request);
+
+    void updateRequest(Request request);
+
+    void cancelRequest(long requestId);
 }

--- a/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
@@ -1,0 +1,5 @@
+package com.mthree.petadoption.service;
+
+public class RequestServiceImpl implements RequestService {
+
+}

--- a/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
@@ -5,7 +5,9 @@ import com.mthree.petadoption.dao.RequestDaoImpl;
 import com.mthree.petadoption.model.Request;
 
 import java.util.List;
+import org.springframework.stereotype.Service;
 
+@Service
 public class RequestServiceImpl implements RequestService {
     private RequestDao requestDao;
 
@@ -20,7 +22,7 @@ public class RequestServiceImpl implements RequestService {
 
     @Override
     public Request viewRequest(long requestId) {
-        return null;
+        return requestDao.viewRequest(requestId);
     }
 
     @Override
@@ -29,8 +31,8 @@ public class RequestServiceImpl implements RequestService {
     }
 
     @Override
-    public void updateRequest(Request request) {
-
+    public void updateRequest(Long requestId, Long petId, String status) {
+        requestDao.updateRequest(requestId, petId, status);
     }
 
     @Override

--- a/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
@@ -1,5 +1,40 @@
 package com.mthree.petadoption.service;
 
-public class RequestServiceImpl implements RequestService {
+import com.mthree.petadoption.dao.RequestDao;
+import com.mthree.petadoption.dao.RequestDaoImpl;
+import com.mthree.petadoption.model.Request;
 
+import java.util.List;
+
+public class RequestServiceImpl implements RequestService {
+    private RequestDao requestDao;
+
+    public RequestServiceImpl(RequestDaoImpl requestDao) {
+        this.requestDao = requestDao;
+    }
+
+    @Override
+    public List<Request> listAllRequests() {
+        return requestDao.listAllRequests();
+    }
+
+    @Override
+    public Request viewRequest(long requestId) {
+        return null;
+    }
+
+    @Override
+    public Request submitRequest(Request request) {
+        return requestDao.submitRequest(request);
+    }
+
+    @Override
+    public void updateRequest(Request request) {
+
+    }
+
+    @Override
+    public void cancelRequest(long requestId) {
+        requestDao.cancelRequest(requestId);
+    }
 }

--- a/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/RequestServiceImpl.java
@@ -5,11 +5,13 @@ import com.mthree.petadoption.dao.RequestDaoImpl;
 import com.mthree.petadoption.model.Request;
 
 import java.util.List;
+
+import com.mthree.petadoption.model.User;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RequestServiceImpl implements RequestService {
-    private RequestDao requestDao;
+    private final RequestDao requestDao;
 
     public RequestServiceImpl(RequestDaoImpl requestDao) {
         this.requestDao = requestDao;

--- a/src/test/java/com/mthree/petadoption/dao/RequestDaoImplTest.java
+++ b/src/test/java/com/mthree/petadoption/dao/RequestDaoImplTest.java
@@ -1,21 +1,64 @@
 package com.mthree.petadoption.dao;
 
+import com.mthree.petadoption.model.Pet;
+import com.mthree.petadoption.model.Request;
+import com.mthree.petadoption.model.User;
+import com.mthree.petadoption.repository.PetRepository;
+import com.mthree.petadoption.repository.RequestRepository;
+import com.mthree.petadoption.repository.UserRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class RequestDaoImplTest {
+    private User user;
+    private Pet pet;
 
-    @Test
-    void listAllRequests() {
+    private RequestDao requestDao;
+    private RequestRepository requestRepository;
+    private UserRepository userRepository;
+    private PetRepository petRepository;
+
+    @Autowired
+    public void RequestDaoImplTest(RequestRepository requestRepository, UserRepository userRepository, PetRepository petRepository) {
+        this.requestRepository = requestRepository;
+        this.petRepository = petRepository;
+        this.userRepository = userRepository;
+        this.requestDao = new RequestDaoImpl(requestRepository, petRepository, userRepository);
     }
 
-    @Test
-    void viewRequest() {
+    @BeforeEach
+    public void setUp(){
+        user = new User();
+        user.setUsername("john_doe");
+        user.setEmail("john@example.com");
+        userRepository.save(user);
+
+        pet = new Pet();
+        pet.setPetName("Charlie");
+        pet.setSpecies("Dog");
+        petRepository.save(pet);
     }
 
     @Test
     void submitRequest() {
+    }
+
+    @Test
+    void listAllRequests() {
+        List<Request> newList = requestDao.listAllRequests();
+        assertNotNull(newList);
+        assertEquals(2, newList.size());
+    }
+
+    @Test
+    void viewRequest() {
     }
 
     @Test

--- a/src/test/java/com/mthree/petadoption/dao/RequestDaoImplTest.java
+++ b/src/test/java/com/mthree/petadoption/dao/RequestDaoImplTest.java
@@ -1,0 +1,28 @@
+package com.mthree.petadoption.dao;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestDaoImplTest {
+
+    @Test
+    void listAllRequests() {
+    }
+
+    @Test
+    void viewRequest() {
+    }
+
+    @Test
+    void submitRequest() {
+    }
+
+    @Test
+    void updateRequest() {
+    }
+
+    @Test
+    void cancelRequest() {
+    }
+}

--- a/src/test/java/com/mthree/petadoption/dao/RequestDaoStubImpl.java
+++ b/src/test/java/com/mthree/petadoption/dao/RequestDaoStubImpl.java
@@ -1,0 +1,51 @@
+package com.mthree.petadoption.dao;
+
+import com.mthree.petadoption.model.Pet;
+import com.mthree.petadoption.model.Request;
+import com.mthree.petadoption.model.User;
+
+import java.util.List;
+
+public class RequestDaoStubImpl implements RequestDao{
+
+    public Request onlyRequest;
+
+    public RequestDaoStubImpl() {
+        //create a new pet and user as a sample
+        Pet pet = new Pet();
+        pet.setPetId(1L);
+
+        User user = new User();
+        user.setUserId(1L);
+
+        onlyRequest = new Request();
+        onlyRequest.setRequestId(121L);
+        onlyRequest.setPet(pet);
+        onlyRequest.setUser(user);
+    }
+
+    @Override
+    public List<Request> listAllRequests() {
+        return List.of();
+    }
+
+    @Override
+    public Request viewRequest(long requestId) {
+        return null;
+    }
+
+    @Override
+    public Request submitRequest(Request request) {
+        return null;
+    }
+
+    @Override
+    public Request updateRequest(Long requestId, Long petId, String status) {
+        return null;
+    }
+
+    @Override
+    public void cancelRequest(long requestId) {
+
+    }
+}


### PR DESCRIPTION

**This pull request adds complete CRUD (Create, Read, Update, Delete) functionality to our pet adoption application.**

## **Changes Made**

### **DAO Layer**

1. **RequestDao Interface:**
   - **Added methods:**
     - `List<Request> listAllRequests();`
     - `Request viewRequest(long requestId);`
     - `Request submitRequest(Request request);`
     - `Request updateRequest(Long requestId, Long petId, String status);`
     - `void cancelRequest(long requestId);`

2. **RequestDaoImpl Implementation:**
   - Implemented `listAllRequests()`, `viewRequest()`, `submitRequest()`, `updateRequest()`, and `cancelRequest()` by delegating operations to the Spring Data JPA repository.
   - **`submitRequest(Request request)`**: Validates whether the user and pet IDs exist before saving the request.
   - **`updateRequest(Long requestId, Long petId, String status)`**: Checks if the pet exists before assigning it and validates the request status.

### **Service Layer**

- **RequestService Interface:**
  - **Added methods for:**
    - Retrieving all requests.
    - Retrieving a request by its ID.
    - Creating a new request.
    - Updating an existing request.
    - Canceling a request.

- **RequestServiceImpl Implementation:**
  - Modified to inject the DAO (`RequestDao`) and delegate all CRUD operations to it.

### **Controller Layer**

- **RequestController:**
  - **Exposes the following endpoints:**
    - **GET `/api/requests`**: Retrieves all requests.
    - **GET `/api/requests/{id}`**: Retrieves a request by its ID. Returns a `404 Not Found` if not found.
    - **POST `/api/request`**: Creates a new request. Returns a `201 Created` status.
    - **PUT `/api/update/{id}`**: Updates an existing request. Returns `200 OK` if successful or `404 Not Found` if the request does not exist.
    - **DELETE `/api/{id}`**: Cancels a request. Returns `204 No Content` if successful.