### PR TITLE
Feature fetch pets data

### DIFF
--- a/src/main/java/com/mthree/petadoption/controller/PetDataFetchController.java
+++ b/src/main/java/com/mthree/petadoption/controller/PetDataFetchController.java
@@ -1,0 +1,25 @@
+package com.mthree.petadoption.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mthree.petadoption.service.PetDataFetchService;
+
+@RestController
+@RequestMapping("/api/data")
+public class PetDataFetchController {
+  private final PetDataFetchService petDataFetchService;
+
+  public PetDataFetchController(PetDataFetchService petDataFetchService) {
+    this.petDataFetchService = petDataFetchService;
+  }
+
+  @PostMapping("/fetch")
+  public ResponseEntity<String> fetchAndStorePets(@RequestParam("token") String token, @RequestParam("zipcode") String zipcode) {
+    String response = petDataFetchService.fetchAndStorePets(token, zipcode);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/mthree/petadoption/dto/PetApiDTO.java
+++ b/src/main/java/com/mthree/petadoption/dto/PetApiDTO.java
@@ -1,0 +1,120 @@
+package com.mthree.petadoption.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PetApiDTO {
+  @JsonProperty("pet_id")
+  private String petId;
+
+  @JsonProperty("pet_name")
+  private String petName;
+
+  private String species;
+  private String size;
+  private String sex;
+  private String age;
+
+  @JsonProperty("primary_breed")
+  private String primaryBreed;
+
+  @JsonProperty("secondary_breed")
+  private String secondaryBreed;
+
+  @JsonProperty("addr_state_code")
+  private String stateCode;
+
+  @JsonProperty("addr_city")
+  private String city;
+
+  @JsonProperty("large_results_photo_url")
+  private String photoUrl;
+
+  // Getters and Setters
+  public String getPetId() {
+    return petId;
+  }
+
+  public void setPetId(String petId) {
+    this.petId = petId;
+  }
+
+  public String getPetName() {
+    return petName;
+  }
+
+  public void setPetName(String petName) {
+    this.petName = petName;
+  }
+
+  public String getSpecies() {
+    return species;
+  }
+
+  public void setSpecies(String species) {
+    this.species = species;
+  }
+
+  public String getSize() {
+    return size;
+  }
+
+  public void setSize(String size) {
+    this.size = size;
+  }
+
+  public String getSex() {
+    return sex;
+  }
+
+  public void setSex(String sex) {
+    this.sex = sex;
+  }
+
+  public String getAge() {
+    return age;
+  }
+
+  public void setAge(String age) {
+    this.age = age;
+  }
+
+  public String getPrimaryBreed() {
+    return primaryBreed;
+  }
+
+  public void setPrimaryBreed(String primaryBreed) {
+    this.primaryBreed = primaryBreed;
+  }
+
+  public String getSecondaryBreed() {
+    return secondaryBreed;
+  }
+
+  public void setSecondaryBreed(String secondaryBreed) {
+    this.secondaryBreed = secondaryBreed;
+  }
+
+  public String getStateCode() {
+    return stateCode;
+  }
+
+  public void setStateCode(String stateCode) {
+    this.stateCode = stateCode;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getPhotoUrl() {
+    return photoUrl;
+  }
+
+  public void setPhotoUrl(String photoUrl) {
+    this.photoUrl = photoUrl;
+  }
+}

--- a/src/main/java/com/mthree/petadoption/dto/PetApiResponseDTO.java
+++ b/src/main/java/com/mthree/petadoption/dto/PetApiResponseDTO.java
@@ -1,0 +1,18 @@
+package com.mthree.petadoption.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PetApiResponseDTO {
+  @JsonProperty("pets")
+  private List<PetApiDTO> pets;
+
+  public List<PetApiDTO> getPets() {
+    return pets;
+  }
+
+  public void setPets(List<PetApiDTO> pets) {
+    this.pets = pets;
+  }
+}

--- a/src/main/java/com/mthree/petadoption/model/Pet.java
+++ b/src/main/java/com/mthree/petadoption/model/Pet.java
@@ -1,6 +1,11 @@
 package com.mthree.petadoption.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "pets")
@@ -10,24 +15,34 @@ public class Pet {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long petId;
 
+  @Column(nullable = false)
   private String species;
+  @Column(length = 50)
   private String size;
+  @Column(length = 1, nullable = false)
   private String sex;
+  @Column(length = 50)
   private String age;
+  @Column(length = 50)
   private String petName;
+  @Column(length = 50)
   private String primaryBreed;
+  @Column(length = 50)
   private String secondaryBreed;
+  @Column(length = 2)
   private String stateCode;
+  @Column(length = 25)
   private String city;
   private String photoUrl;
+  @Column(nullable = false)
   private String status;
 
   public Pet() {
   }
 
   public Pet(String species, String size, String sex, String age, String petName,
-             String primaryBreed, String secondaryBreed, String stateCode, String city,
-             String photoUrl, String status) {
+      String primaryBreed, String secondaryBreed, String stateCode, String city,
+      String photoUrl, String status) {
     this.species = species;
     this.size = size;
     this.sex = sex;

--- a/src/main/java/com/mthree/petadoption/service/PetDataFetchService.java
+++ b/src/main/java/com/mthree/petadoption/service/PetDataFetchService.java
@@ -1,0 +1,85 @@
+package com.mthree.petadoption.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.mthree.petadoption.dto.PetApiDTO;
+import com.mthree.petadoption.dto.PetApiResponseDTO;
+import com.mthree.petadoption.model.Pet;
+import com.mthree.petadoption.repository.PetRepository;
+
+@Service
+public class PetDataFetchService {
+  private final PetRepository petRepository;
+  private final RestTemplate restTemplate;
+
+  @Value("${api.key}")
+  private String apiKey;
+
+  @Value("${fetch.token}")
+  private String SECRET;
+
+  // @Value("${api.zipcode}")
+  // private String zipCode;
+
+  private static final String[] SPECIES = { "cat", "dog", "rabbit", "bird", "reptile", "small_animal" };
+
+  public PetDataFetchService(PetRepository petRepository) {
+    this.petRepository = petRepository;
+    this.restTemplate = new RestTemplate();
+  }
+
+  public String fetchAndStorePets(String token, String zipcode) {
+    if (!token.equals(SECRET)) {
+      return "Invalid token. Fetch failed.";
+    }
+
+    int storedPets = 0;
+    for (String species : SPECIES) {
+      String apiUrl = "https://api-staging.adoptapet.com/search/pet_search?key=" + apiKey +
+          "&v=3&output=json&city_or_zip=" + zipcode +
+          "&geo_range=10&species=" + species +
+          "&start_number=1&end_number=100";
+
+      try {
+        PetApiResponseDTO response = restTemplate.getForObject(apiUrl, PetApiResponseDTO.class);
+
+        if (response != null && response.getPets() != null) {
+          storedPets += savePetsToDatabase(species, response.getPets());
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+        return "Error occurred during fetching.";
+      }
+    }
+    return "Successfully stored " + storedPets + " pets.";
+  }
+
+  private int savePetsToDatabase(String species, List<PetApiDTO> petList) {
+    int count = 0;
+    for (PetApiDTO petDTO : petList) {
+      if (petDTO.getSex() == null)
+        continue;
+
+      Pet pet = new Pet(
+          species,
+          petDTO.getSize(),
+          petDTO.getSex(),
+          petDTO.getAge(),
+          petDTO.getPetName(),
+          petDTO.getPrimaryBreed(),
+          petDTO.getSecondaryBreed(),
+          petDTO.getStateCode(),
+          petDTO.getCity(),
+          petDTO.getPhotoUrl(),
+          "available");
+
+      petRepository.save(pet);
+      count++;
+    }
+    return count;
+  }
+}

--- a/src/main/java/com/mthree/petadoption/service/PetDataFetchService.java
+++ b/src/main/java/com/mthree/petadoption/service/PetDataFetchService.java
@@ -22,9 +22,6 @@ public class PetDataFetchService {
   @Value("${fetch.token}")
   private String SECRET;
 
-  // @Value("${api.zipcode}")
-  // private String zipCode;
-
   private static final String[] SPECIES = { "cat", "dog", "rabbit", "bird", "reptile", "small_animal" };
 
   public PetDataFetchService(PetRepository petRepository) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,8 @@ spring.datasource.username=root
 spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.open-in-view=false
+
+api.key=hg4nsv85lppeoqqixy3tnlt3k8lj6o0c
+fetch.token=THINK_TWICE

--- a/src/test/java/com/mthree/petadoption/dao/PetDaoImplTest.java
+++ b/src/test/java/com/mthree/petadoption/dao/PetDaoImplTest.java
@@ -1,0 +1,105 @@
+package com.mthree.petadoption.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.mthree.petadoption.model.Pet;
+import com.mthree.petadoption.repository.PetRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PetDaoImplTest {
+  @InjectMocks
+  private PetDAOImpl petDAO;
+
+  @Mock
+  private PetRepository petRepository;
+
+  private Pet mockPet;
+
+  @BeforeEach
+  void setUp() {
+    mockPet = new Pet();
+    mockPet.setPetId(1L);
+    mockPet.setSpecies("Dog");
+    mockPet.setSize("Medium");
+    mockPet.setSex("M");
+    mockPet.setAge("Young");
+    mockPet.setPetName("Buddy");
+    mockPet.setPrimaryBreed("Labrador");
+    mockPet.setStatus("Available");
+  }
+
+  @Test
+  void testCreatePet() {
+    when(petRepository.save(any(Pet.class))).thenReturn(mockPet);
+
+    Pet created = petDAO.savePet(mockPet);
+    assertNotNull(created);
+    assertEquals("Buddy", created.getPetName());
+    verify(petRepository).save(mockPet);
+  }
+
+  @Test
+  void testFindAllPets() {
+    when(petRepository.findAll()).thenReturn(Arrays.asList(mockPet));
+
+    List<Pet> pets = petDAO.findAllPets();
+
+    assertNotNull(pets);
+    assertEquals(1, pets.size());
+    verify(petRepository, times(1)).findAll();
+  }
+
+  @Test
+  void testFindPetById() {
+    when(petRepository.findById(1L)).thenReturn(Optional.of(mockPet));
+
+    Optional<Pet> foundPet = petDAO.findPetById(1L);
+
+    assertTrue(foundPet.isPresent());
+    assertEquals("Buddy", foundPet.get().getPetName());
+    verify(petRepository, times(1)).findById(1L);
+  }
+
+  @Test
+  void testDeletePet() {
+    when(petRepository.existsById(1L)).thenReturn(true);
+    doNothing().when(petRepository).deleteById(1L);
+
+    boolean result = petDAO.deletePet(1L);
+
+    assertTrue(result);
+    verify(petRepository, times(1)).deleteById(1L);
+  }
+
+  @Test
+  void testFindPetBySpecies() {
+    when(petRepository.findBySpecies("Dog")).thenReturn(Arrays.asList(mockPet));
+
+    List<Pet> pets = petDAO.findPetBySpecies("Dog");
+
+    assertNotNull(pets);
+    assertFalse(pets.isEmpty());
+    assertEquals(1, pets.size());
+    assertEquals("Dog", pets.get(0).getSpecies());
+    verify(petRepository, times(1)).findBySpecies("Dog");
+  }
+}


### PR DESCRIPTION
### Implemented API Data Fetching Service
- Added functionality to **fetch pet data from Adopt-a-Pet API** and store it in the database.
- The fetch operation is **manually triggered** via:
```http
  POST /api/data/fetch?token=YOUR_SECRET&zipcode=YOUR_ZIPCODE
```

- Introduced a security mechanism requiring a secret token to prevent unauthorized or accident execution.

### Added Unit Tests for Pet DAO
- Implemented **Mockito-based tests** for `PetDAO` methods:
  - `findAllPets()`
  - `findPetById()`
  - `savePet()`
  - `createPet()`
  - `deletePet()`