### PR TITLE
Add pagination to GET /api/pets endpoint

### DIFF
--- a/src/main/java/com/mthree/petadoption/controller/PetController.java
+++ b/src/main/java/com/mthree/petadoption/controller/PetController.java
@@ -3,6 +3,8 @@ package com.mthree.petadoption.controller;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mthree.petadoption.model.Pet;
@@ -26,9 +29,17 @@ public class PetController {
     this.petService = petService;
   }
 
+  // leave this here temporary, might use it later
+  // will delete it later if it's not gonna be used
+  // @GetMapping("/all")
+  // public List<Pet> getAllPets() {
+  // return petService.getAllPets();
+  // }
+
   @GetMapping
-  public List<Pet> getAllPets() {
-    return petService.getAllPets();
+  public Page<Pet> getAllPets(@RequestParam(defaultValue = "0") int page,
+    @RequestParam(defaultValue = "10") int size) {
+      return petService.getAllPets(PageRequest.of(page, size));
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/mthree/petadoption/dao/PetDAO.java
+++ b/src/main/java/com/mthree/petadoption/dao/PetDAO.java
@@ -3,10 +3,15 @@ package com.mthree.petadoption.dao;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.mthree.petadoption.model.Pet;
 
 public interface PetDAO {
   List<Pet> findAllPets();
+
+  Page<Pet> findAllPets(Pageable pageable);
 
   Optional<Pet> findPetById(Long id);
 

--- a/src/main/java/com/mthree/petadoption/dao/PetDAOImpl.java
+++ b/src/main/java/com/mthree/petadoption/dao/PetDAOImpl.java
@@ -3,6 +3,8 @@ package com.mthree.petadoption.dao;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.mthree.petadoption.model.Pet;
@@ -48,5 +50,10 @@ public class PetDAOImpl implements PetDAO {
   @Override
   public Pet updatePet(Pet pet) {
     return petRepository.save(pet);
+  }
+
+  @Override
+  public Page<Pet> findAllPets(Pageable pageable) {
+    return petRepository.findAll(pageable);
   }
 }

--- a/src/main/java/com/mthree/petadoption/repository/PetRepository.java
+++ b/src/main/java/com/mthree/petadoption/repository/PetRepository.java
@@ -1,10 +1,15 @@
 package com.mthree.petadoption.repository;
 
-import com.mthree.petadoption.model.Pet;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import com.mthree.petadoption.model.Pet;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
   List<Pet> findBySpecies(String species);
+
+  Page<Pet> findAll(Pageable pageable);
 }

--- a/src/main/java/com/mthree/petadoption/service/PetService.java
+++ b/src/main/java/com/mthree/petadoption/service/PetService.java
@@ -3,13 +3,23 @@ package com.mthree.petadoption.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.mthree.petadoption.model.Pet;
 
 public interface PetService {
   List<Pet> getAllPets();
+
   Optional<Pet> getPetById(Long id);
+
   Pet savePet(Pet pet);
+
   Optional<Pet> updatePet(Long id, Pet pet);
+
   boolean deletePet(Long id);
+
   List<Pet> getPetsBySpecies(String species);
+
+  Page<Pet> getAllPets(Pageable pageable);
 }

--- a/src/main/java/com/mthree/petadoption/service/PetServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/PetServiceImpl.java
@@ -3,6 +3,8 @@ package com.mthree.petadoption.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.mthree.petadoption.dao.PetDAO;
@@ -91,5 +93,10 @@ public class PetServiceImpl implements PetService {
     if (pet.getStatus() == null || pet.getStatus().trim().isEmpty()) {
       throw new IllegalArgumentException("Status is required.");
     }
+  }
+
+  @Override
+  public Page<Pet> getAllPets(Pageable pageable) {
+    return petDAO.findAllPets(pageable);
   }
 }


### PR DESCRIPTION
### Added Pagination Support for Pet Listing

- Updated the backend to support pagination on the `GET /api/pets` endpoint
```bash
GET /api/pets?page=0&size=10
```
- default size set to 10, but can be override