### PR TITLE
Fix new user registration

### DIFF
--- a/src/main/java/com/mthree/petadoption/controller/UserController.java
+++ b/src/main/java/com/mthree/petadoption/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.mthree.petadoption.dto.UserRegistrationDTO;
 import com.mthree.petadoption.model.User;
 import com.mthree.petadoption.model.UserInfo;
 import com.mthree.petadoption.service.UserService;
@@ -41,8 +42,12 @@ public class UserController {
     return ResponseEntity.notFound().build();
   }
 
-  @PostMapping
-  public ResponseEntity<User> createUser(@RequestBody User user) {
+  @PostMapping("/register")
+  public ResponseEntity<User> createUser(@RequestBody UserRegistrationDTO userDTO) {
+    User user = new User();
+    user.setUsername(userDTO.username());
+    user.setEmail(userDTO.email());
+    user.setPassword(userDTO.password());
     User createdUser = userService.saveUser(user);
     return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
   }

--- a/src/main/java/com/mthree/petadoption/dto/UserRegistrationDTO.java
+++ b/src/main/java/com/mthree/petadoption/dto/UserRegistrationDTO.java
@@ -1,0 +1,5 @@
+package com.mthree.petadoption.dto;
+
+public record UserRegistrationDTO(String username, String email, String password) {
+
+}

--- a/src/main/java/com/mthree/petadoption/service/UserServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/UserServiceImpl.java
@@ -23,6 +23,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public User saveUser(User user) {
+    user.setRole(User.Role.ADOPTER);
     return userDao.createUser(user);
   }
 
@@ -39,7 +40,6 @@ public class UserServiceImpl implements UserService {
       userToUpdate.setUsername(user.getUsername());
       userToUpdate.setEmail(user.getEmail());
       userToUpdate.setPassword(user.getPassword());
-      userToUpdate.setRole(user.getRole());
       User updatedUser = userDao.updateUser(userToUpdate);
       return Optional.of(updatedUser);
     }


### PR DESCRIPTION
### User Registration Improvements

- Updated the registration endpoint to automatically assign the role `ADOPTER` to new users.
- Removed the need to explicitly provide `role` during registration via the API.
- Added `UserRegistrationDTO` using Java `record` for clean and secure data transfer.