### PR TITLE
Seed Admin User and Add Initial Schema/Data SQL Scripts

### DIFF
--- a/src/main/java/com/mthree/petadoption/DataInitializer.java
+++ b/src/main/java/com/mthree/petadoption/DataInitializer.java
@@ -1,0 +1,27 @@
+package com.mthree.petadoption;
+
+import com.mthree.petadoption.model.User;
+import com.mthree.petadoption.model.User.Role;
+import com.mthree.petadoption.repository.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DataInitializer {
+
+  @Bean
+  CommandLineRunner insertAdmin(UserRepository userRepository) {
+    return args -> {
+      if (!userRepository.existsById(1L)) {
+        User admin = new User();
+        admin.setUsername("admin");
+        admin.setEmail("admin@example.com");
+        admin.setPassword("adminpass");
+        admin.setRole(Role.ADMIN);
+
+        userRepository.save(admin);
+      }
+    };
+  }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,17 @@
+INSERT INTO users (username, email, password, role)
+VALUES ('jdoe', 'jdoe@example.com', 'hashedpassword123', 'adopter'),
+       ('admin1', 'admin@example.com', 'adminpass456', 'admin'),
+       ('lily', 'lily@example.com', 'lilypass789', 'adopter'),
+       ('max', 'max@example.com', 'maxsecure321', 'adopter');
+
+INSERT INTO user_info (user_id, firstName, lastName, phone_number, birthDate)
+VALUES (1, 'John', 'Doe', '1234567890', '1990-01-01'),
+       (2, 'Admin', 'User', '0987654321', '1985-05-15'),
+       (3, 'Lily', 'Evans', '1112223333', '1995-09-09'),
+       (4, 'Max', 'Turner', '4445556666', '1988-12-12');
+
+INSERT INTO requests (pet_id, user_id, request_date, message, status)
+VALUES (1, 1, '2025-03-01', 'I would love to adopt this pet!', 'pending'),
+       (2, 1, '2025-03-02', 'Can I meet this pet before adopting?', 'approved'),
+       (3, 3, '2025-03-05', 'Looking for a calm pet for my apartment.', 'pending'),
+       (4, 4, '2025-03-06', 'Perfect companion for my child.', 'rejected');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,47 @@
+CREATE TABLE users
+(
+    id       INT PRIMARY KEY AUTO_INCREMENT,
+    username VARCHAR(25)  NOT NULL,
+    email    VARCHAR(100) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role     ENUM ('ADMIN','ADOPTER') NOT NULL
+);
+
+CREATE TABLE user_info
+(
+    id           INT PRIMARY KEY AUTO_INCREMENT,
+    user_id      INT,
+    firstName    VARCHAR(50) NOT NULL,
+    lastName     VARCHAR(50) NOT NULL,
+    phone_number CHAR(15),
+    birthDate    DATE,
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE pets
+(
+    pet_id INT PRIMARY KEY AUTO_INCREMENT,
+    species ENUM('dog', 'cat', 'rabbit', 'other') NOT NULL,
+    size VARCHAR(50),
+    sex VARCHAR(1),
+    age VARCHAR(50),
+    pet_name VARCHAR(25),
+    primary_breed VARCHAR(50),
+    secondary_breed VARCHAR(50),
+    state_code CHAR(2),
+    city VARCHAR(25),
+    photo_url VARCHAR(255),
+    status ENUM('available', 'pending', 'adopted') NOT NULL
+);
+
+CREATE TABLE requests
+(
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    pet_id      INT,
+    user_id     INT,
+    requestDate DATE,
+    message     TEXT,
+    status ENUM('pending', 'approved', 'rejected') NOT NULL,
+    CONSTRAINT fk_pet FOREIGN KEY (pet_id) REFERENCES pets (pet_id),
+    CONSTRAINT fk_request_user FOREIGN KEY (user_id) REFERENCES users (id)
+);


### PR DESCRIPTION
## Seed Admin User and Add Initial Schema/Data SQL Scripts

### Summary

This PR adds the following:

1. A `DataInitializer` class that seeds a default admin user when the application starts.
2. A `schema.sql` file to create the database structure.
3. A `data.sql` file to populate the database with sample users, user info, and requests.