### PR TITLE
Add pagination support for fetching pets by species

### DIFF
--- a/src/main/java/com/mthree/petadoption/controller/PetController.java
+++ b/src/main/java/com/mthree/petadoption/controller/PetController.java
@@ -1,16 +1,26 @@
 package com.mthree.petadoption.controller;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+import com.mthree.petadoption.dto.pet.PetResponse;
 import com.mthree.petadoption.model.Pet;
 import com.mthree.petadoption.service.PetService;
+
 @CrossOrigin(origins = "http://localhost:3000")
 @RestController
 @RequestMapping("/api/pets")
@@ -30,8 +40,8 @@ public class PetController {
 
   @GetMapping
   public Page<Pet> getAllPets(@RequestParam(defaultValue = "0") int page,
-    @RequestParam(defaultValue = "10") int size) {
-      return petService.getAllPets(PageRequest.of(page, size));
+      @RequestParam(defaultValue = "10") int size) {
+    return petService.getAllPets(PageRequest.of(page, size));
   }
 
   @GetMapping("/{id}")
@@ -69,11 +79,17 @@ public class PetController {
   }
 
   @GetMapping("/species/{species}")
-  public ResponseEntity<List<Pet>> getPetsBySpecies(@PathVariable String species) {
-    List<Pet> pets = petService.getPetsBySpecies(species);
-    if (pets == null || pets.isEmpty()) {
-      return ResponseEntity.notFound().build();
-    }
-    return ResponseEntity.ok(pets);
+  public ResponseEntity<PetResponse> getPetsBySpecies(
+      @PathVariable String species,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+    Page<Pet> petsPage = petService.getPetsBySpecies(species, PageRequest.of(page, size));
+    return ResponseEntity.ok(new PetResponse(
+        petsPage.getContent(),
+        petsPage.getNumber(),
+        petsPage.getSize(),
+        petsPage.getTotalElements(),
+        petsPage.getTotalPages(),
+        petsPage.isLast()));
   }
 }

--- a/src/main/java/com/mthree/petadoption/dao/PetDAO.java
+++ b/src/main/java/com/mthree/petadoption/dao/PetDAO.java
@@ -22,4 +22,6 @@ public interface PetDAO {
   boolean deletePet(Long id);
 
   List<Pet> findPetBySpecies(String species);
+
+  Page<Pet> findPetBySpecies(String species, Pageable pageable);
 }

--- a/src/main/java/com/mthree/petadoption/dao/PetDAOImpl.java
+++ b/src/main/java/com/mthree/petadoption/dao/PetDAOImpl.java
@@ -56,4 +56,9 @@ public class PetDAOImpl implements PetDAO {
   public Page<Pet> findAllPets(Pageable pageable) {
     return petRepository.findAll(pageable);
   }
+
+  @Override
+  public Page<Pet> findPetBySpecies(String species, Pageable pageable) {
+    return petRepository.findBySpecies(species, pageable);
+  }
 }

--- a/src/main/java/com/mthree/petadoption/dto/pet/PetResponse.java
+++ b/src/main/java/com/mthree/petadoption/dto/pet/PetResponse.java
@@ -1,0 +1,14 @@
+package com.mthree.petadoption.dto.pet;
+
+import java.util.List;
+
+import com.mthree.petadoption.model.Pet;
+
+public record PetResponse(
+    List<Pet> content,
+    int pageNumber,
+    int pageSize,
+    long totalElements,
+    int totalPages,
+    boolean last) {
+}

--- a/src/main/java/com/mthree/petadoption/dto/petapi/PetApiDTO.java
+++ b/src/main/java/com/mthree/petadoption/dto/petapi/PetApiDTO.java
@@ -1,4 +1,4 @@
-package com.mthree.petadoption.dto;
+package com.mthree.petadoption.dto.petapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/mthree/petadoption/dto/petapi/PetApiResponseDTO.java
+++ b/src/main/java/com/mthree/petadoption/dto/petapi/PetApiResponseDTO.java
@@ -1,4 +1,4 @@
-package com.mthree.petadoption.dto;
+package com.mthree.petadoption.dto.petapi;
 
 import java.util.List;
 

--- a/src/main/java/com/mthree/petadoption/repository/PetRepository.java
+++ b/src/main/java/com/mthree/petadoption/repository/PetRepository.java
@@ -12,4 +12,6 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
   List<Pet> findBySpecies(String species);
 
   Page<Pet> findAll(Pageable pageable);
+
+  Page<Pet> findBySpecies(String species, Pageable pageable);
 }

--- a/src/main/java/com/mthree/petadoption/service/PetDataFetchService.java
+++ b/src/main/java/com/mthree/petadoption/service/PetDataFetchService.java
@@ -6,8 +6,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import com.mthree.petadoption.dto.PetApiDTO;
-import com.mthree.petadoption.dto.PetApiResponseDTO;
+import com.mthree.petadoption.dto.petapi.PetApiDTO;
+import com.mthree.petadoption.dto.petapi.PetApiResponseDTO;
 import com.mthree.petadoption.model.Pet;
 import com.mthree.petadoption.repository.PetRepository;
 

--- a/src/main/java/com/mthree/petadoption/service/PetService.java
+++ b/src/main/java/com/mthree/petadoption/service/PetService.java
@@ -22,4 +22,6 @@ public interface PetService {
   List<Pet> getPetsBySpecies(String species);
 
   Page<Pet> getAllPets(Pageable pageable);
+
+  Page<Pet> getPetsBySpecies(String species, Pageable pageable);
 }

--- a/src/main/java/com/mthree/petadoption/service/PetServiceImpl.java
+++ b/src/main/java/com/mthree/petadoption/service/PetServiceImpl.java
@@ -24,6 +24,11 @@ public class PetServiceImpl implements PetService {
   }
 
   @Override
+  public Page<Pet> getAllPets(Pageable pageable) {
+    return petDAO.findAllPets(pageable);
+  }
+
+  @Override
   public Optional<Pet> getPetById(Long id) {
     return petDAO.findPetById(id);
   }
@@ -42,6 +47,11 @@ public class PetServiceImpl implements PetService {
   @Override
   public List<Pet> getPetsBySpecies(String species) {
     return petDAO.findPetBySpecies(species);
+  }
+
+  @Override
+  public Page<Pet> getPetsBySpecies(String species, Pageable pageable) {
+    return petDAO.findPetBySpecies(species, pageable);
   }
 
   @Override
@@ -93,10 +103,5 @@ public class PetServiceImpl implements PetService {
     if (pet.getStatus() == null || pet.getStatus().trim().isEmpty()) {
       throw new IllegalArgumentException("Status is required.");
     }
-  }
-
-  @Override
-  public Page<Pet> getAllPets(Pageable pageable) {
-    return petDAO.findAllPets(pageable);
   }
 }


### PR DESCRIPTION
### Add Pagination for Species-Specific Pet Listings
- Introduced pagination to the `GET /api/pets/species/{species}` endpoint using `Pageable`.
- Updated `PetService`, `PetDAO`, and `PetRepository` to support paginated queries by species.
- Modified the frontend `SpeciesPetsPage` to match the updates